### PR TITLE
[REFACTOR] : 온보딩 공통 레이아웃 컴포넌트로 전환

### DIFF
--- a/app/(onboarding)/step1.tsx
+++ b/app/(onboarding)/step1.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import Center from '../../assets/GUI/emotion/emotion_done.svg';
 import Back from '../../assets/icon/arrow/back_arrow.svg';
 import Intro from '../../assets/temp/report.svg';
+import StepButton from '../../components/shared/StepButton';
 //폰트, 컬러
 import { Colors } from '../../constants/Colors';
 import { Typo } from '../../constants/Typo';
@@ -48,16 +49,10 @@ export default function ScreenRole() {
           </TouchableOpacity>
         </View>
         {textIndex === 2 && (
-          <TouchableOpacity
-            style={styles.bottomButtonWrapper}
+          <StepButton
+            text="시작하기"
             onPress={() => router.push('/step2')}
-          >
-            <View style={[styles.button, { backgroundColor: Colors.main500 }]}>
-              <Text style={[Typo.heading02, { color: Colors.gray800 }]}>
-                시작하기
-              </Text>
-            </View>
-          </TouchableOpacity>
+          />
         )}
       </SafeAreaView>
     );
@@ -100,14 +95,10 @@ export default function ScreenRole() {
           </Text>
         </View>
       </View>
-      <TouchableOpacity
-        style={styles.bottomButtonWrapper}
+      <StepButton
+        text="다음"
         onPress={() => setShowIntro(true)}
-      >
-        <View style={[styles.button, { backgroundColor: Colors.main500 }]}>
-          <Text style={[Typo.heading02, { color: Colors.gray800 }]}>다음</Text>
-        </View>
-      </TouchableOpacity>
+      />
     </SafeAreaView>
   );
 }
@@ -140,20 +131,6 @@ const styles = StyleSheet.create({
   introWrapper: {
     flex: 1,
     top: '25%',
-    alignItems: 'center',
-  },
-  bottomButtonWrapper: {
-    position: 'absolute',
-    bottom: '5%',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  button: {
-    width: 336,
-    height: 60,
-    borderRadius: 12,
-    justifyContent: 'center',
     alignItems: 'center',
   },
 });

--- a/app/(onboarding)/step2.tsx
+++ b/app/(onboarding)/step2.tsx
@@ -1,27 +1,13 @@
-// app/(onboarding)/start.tsx
 import { useState } from 'react';
 
-import { StyleSheet, Text, View } from 'react-native';
-import {
-  Keyboard,
-  KeyboardAvoidingView,
-  Platform,
-  TouchableOpacity,
-  TouchableWithoutFeedback,
-} from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import { useRouter } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import Center_off from '../../assets/GUI/emotion/emotion_off.svg';
 import Center_on from '../../assets/GUI/emotion/emotion_on.svg';
 import FloatingButton from '../../components/FloatingButton';
-//컴포넌트
-import Header from '../../components/Header';
-import ProgressBar from '../../components/ProgressBar';
-//폰트, 컬러
-import { Colors } from '../../constants/Colors';
-import { Typo } from '../../constants/Typo';
+import OnboardingLayout from '../../components/layout/OnboardingLayout';
 
 const labels = [
   '학습·언어',
@@ -47,102 +33,42 @@ export default function ScreenPhone() {
   ];
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    <OnboardingLayout
+      title="STEP 1 목표 설정"
+      mainTitle={'달성하고 싶은 목표의\n카테고리를 선택해주세요.'}
+      subtitle="하나의 카테고리를 선택해주세요."
+      progress={0.2}
+      bottomButton={{
+        text: '다음',
+        onPress: () =>
+          router.push(`/step3?category=${encodeURIComponent(selected || '')}`),
+        disabled: !selected,
+      }}
     >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <SafeAreaView style={styles.container}>
-          <Header title="STEP 1 목표 설정" />
-          <View style={styles.titleWrapper}>
-            <Text style={[Typo.title03, { color: Colors.gray900 }]}>
-              달성하고 싶은 목표의{'\n'}카테고리를 선택해주세요.
-            </Text>
-          </View>
-          <ProgressBar progress={0} />
-          <View style={styles.subtitleWrapper}>
-            <Text style={[Typo.label02, { color: Colors.gray500 }]}>
-              하나의 카테고리를 선택해주세요.
-            </Text>
-          </View>
-          <View style={styles.floatingButtonContainer}>
-            {labels.map((label, index) => (
-              <FloatingButton
-                key={label}
-                label={label}
-                active={selected === label}
-                onPress={() => setSelected(label)}
-                top={buttonData[index].top}
-                left={buttonData[index].left}
-                size={buttonData[index].size}
-              />
-            ))}
-          </View>
-          <View style={{ marginBottom: 20 }}>
-            {selected ? (
-              <Center_on width="100%" />
-            ) : (
-              <Center_off width="100%" />
-            )}
-          </View>
-          <TouchableOpacity
-            style={styles.bottomButtonWrapper}
-            disabled={!selected}
-            onPress={() =>
-              router.push(
-                `/step3?category=${encodeURIComponent(selected || '')}`,
-              )
-            }
-          >
-            <View
-              style={[
-                styles.button,
-                { backgroundColor: selected ? Colors.main500 : Colors.gray100 },
-              ]}
-            >
-              <Text style={[Typo.heading02, { color: Colors.gray800 }]}>
-                다음
-              </Text>
-            </View>
-          </TouchableOpacity>
-        </SafeAreaView>
-      </TouchableWithoutFeedback>
-    </KeyboardAvoidingView>
+      <View style={styles.floatingButtonContainer}>
+        {labels.map((label, index) => (
+          <FloatingButton
+            key={label}
+            label={label}
+            active={selected === label}
+            onPress={() => setSelected(label)}
+            top={buttonData[index].top}
+            left={buttonData[index].left}
+            size={buttonData[index].size}
+          />
+        ))}
+      </View>
+      <View style={{ marginBottom: 20 }}>
+        {selected ? <Center_on width="100%" /> : <Center_off width="100%" />}
+      </View>
+    </OnboardingLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.gray0,
-  },
-  titleWrapper: {
-    height: '10%',
-    paddingHorizontal: 20,
-    justifyContent: 'flex-end',
-    marginBottom: 15,
-  },
-  subtitleWrapper: {
-    marginTop: 8,
-    paddingHorizontal: 20,
-  },
   floatingButtonContainer: {
     position: 'relative',
     height: 250,
     marginVertical: 20,
-  },
-  bottomButtonWrapper: {
-    position: 'absolute',
-    bottom: '5%',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  button: {
-    width: 336,
-    height: 60,
-    borderRadius: 12,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 });

--- a/app/(onboarding)/step2.tsx
+++ b/app/(onboarding)/step2.tsx
@@ -8,6 +8,7 @@ import Center_off from '../../assets/GUI/emotion/emotion_off.svg';
 import Center_on from '../../assets/GUI/emotion/emotion_on.svg';
 import FloatingButton from '../../components/FloatingButton';
 import OnboardingLayout from '../../components/layout/OnboardingLayout';
+import StepButton from '../../components/shared/StepButton';
 
 const labels = [
   '학습·언어',
@@ -33,35 +34,39 @@ export default function ScreenPhone() {
   ];
 
   return (
-    <OnboardingLayout
-      title="STEP 1 목표 설정"
-      mainTitle={'달성하고 싶은 목표의\n카테고리를 선택해주세요.'}
-      subtitle="하나의 카테고리를 선택해주세요."
-      progress={0.2}
-      bottomButton={{
-        text: '다음',
-        onPress: () =>
-          router.push(`/step3?category=${encodeURIComponent(selected || '')}`),
-        disabled: !selected,
-      }}
-    >
-      <View style={styles.floatingButtonContainer}>
-        {labels.map((label, index) => (
-          <FloatingButton
-            key={label}
-            label={label}
-            active={selected === label}
-            onPress={() => setSelected(label)}
-            top={buttonData[index].top}
-            left={buttonData[index].left}
-            size={buttonData[index].size}
-          />
-        ))}
-      </View>
-      <View style={{ marginBottom: 20 }}>
-        {selected ? <Center_on width="100%" /> : <Center_off width="100%" />}
-      </View>
-    </OnboardingLayout>
+    <>
+      <OnboardingLayout
+        title="STEP 1 목표 설정"
+        mainTitle={'달성하고 싶은 목표의\n카테고리를 선택해주세요.'}
+        subtitle="하나의 카테고리를 선택해주세요."
+        progress={0.2}
+      >
+        <View style={styles.floatingButtonContainer}>
+          {labels.map((label, index) => (
+            <FloatingButton
+              key={label}
+              label={label}
+              active={selected === label}
+              onPress={() => setSelected(label)}
+              top={buttonData[index].top}
+              left={buttonData[index].left}
+              size={buttonData[index].size}
+            />
+          ))}
+        </View>
+        <View style={{ marginBottom: 20 }}>
+          {selected ? <Center_on width="100%" /> : <Center_off width="100%" />}
+        </View>
+      </OnboardingLayout>
+
+      <StepButton
+        text="다음"
+        onPress={() =>
+          router.push(`/step3?category=${encodeURIComponent(selected || '')}`)
+        }
+        disabled={!selected}
+      />
+    </>
   );
 }
 

--- a/app/(onboarding)/step3.tsx
+++ b/app/(onboarding)/step3.tsx
@@ -1,23 +1,12 @@
-// app/(onboarding)/start.tsx
 import { useState } from 'react';
 
 import { StyleSheet, Text, TextInput, View } from 'react-native';
-import {
-  Keyboard,
-  KeyboardAvoidingView,
-  Platform,
-  TouchableOpacity,
-  TouchableWithoutFeedback,
-} from 'react-native';
+import { TouchableOpacity } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import XIcon from '../../assets/icon/x.svg';
-//컴포넌트
-import Header from '../../components/Header';
-import ProgressBar from '../../components/ProgressBar';
-//폰트, 컬러
+import OnboardingLayout from '../../components/layout/OnboardingLayout';
 import { Colors } from '../../constants/Colors';
 import { Typo } from '../../constants/Typo';
 
@@ -27,110 +16,69 @@ export default function ScreenCode() {
   const [goalText, setGoalText] = useState('');
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    <OnboardingLayout
+      title="STEP 2 목표 정의"
+      mainTitle={'해당 카테고리의\nMain Goal을 입력해주세요.'}
+      subtitle="이 카테고리를 통해 이루고 싶은 최종 목표를 자유롭게 적어보세요."
+      progress={0.4}
+      bottomButton={{
+        text: '다음',
+        onPress: () =>
+          router.push(
+            `/step4?category=${encodeURIComponent(
+              (category as string) || '',
+            )}&goalText=${encodeURIComponent(goalText)}`,
+          ),
+        disabled: !goalText,
+      }}
     >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <SafeAreaView style={styles.container}>
-          <Header title="STEP 2 목표 정의" />
-          <View style={styles.titleWrapper}>
-            <Text style={[Typo.title03, { color: Colors.gray900 }]}>
-              해당 카테고리의{'\n'}Main Goal을 입력해주세요.
-            </Text>
-          </View>
-          <ProgressBar progress={0.25} />
-          <View style={styles.subtitleWrapper}>
-            <Text style={[Typo.label02, { color: Colors.gray500 }]}>
-              이 카테고리를 통해 이루고 싶은 최종 목표를 자유롭게 적어보세요.
-            </Text>
-          </View>
-          <View style={styles.categoryContainer}>
-            <View style={styles.categoryBox}>
-              <Text style={[Typo.heading03, { color: Colors.gray900 }]}>
-                {category || '선택된 카테고리'}
-              </Text>
-            </View>
-          </View>
-          <View style={styles.inputContainer}>
-            <View
+      <View style={styles.categoryContainer}>
+        <View style={styles.categoryBox}>
+          <Text style={[Typo.heading03, { color: Colors.gray900 }]}>
+            {category || '선택된 카테고리'}
+          </Text>
+        </View>
+      </View>
+      <View style={styles.inputContainer}>
+        <View
+          style={[
+            styles.inputBox,
+            {
+              borderBottomColor: goalText ? Colors.main600 : Colors.gray200,
+            },
+          ]}
+        >
+          <View style={styles.inputRow}>
+            <TextInput
               style={[
-                styles.inputBox,
+                Typo.body02,
                 {
-                  borderBottomColor: goalText ? Colors.main600 : Colors.gray200,
+                  color: goalText ? Colors.gray600 : Colors.gray300,
+                  flex: 1,
                 },
               ]}
-            >
-              <View style={styles.inputRow}>
-                <TextInput
-                  style={[
-                    Typo.body02,
-                    {
-                      color: goalText ? Colors.gray600 : Colors.gray300,
-                      flex: 1,
-                    },
-                  ]}
-                  placeholder="이루고 싶은 목표 입력하기"
-                  placeholderTextColor={Colors.gray300}
-                  value={goalText}
-                  onChangeText={setGoalText}
+              placeholder="이루고 싶은 목표 입력하기"
+              placeholderTextColor={Colors.gray300}
+              value={goalText}
+              onChangeText={setGoalText}
+            />
+            <TouchableOpacity onPress={() => setGoalText('')}>
+              <View style={styles.iconBox}>
+                <XIcon
+                  width={20}
+                  height={20}
+                  color={goalText ? Colors.main600 : Colors.gray200}
                 />
-                <TouchableOpacity onPress={() => setGoalText('')}>
-                  <View style={styles.iconBox}>
-                    <XIcon
-                      width={20}
-                      height={20}
-                      color={goalText ? Colors.main600 : Colors.gray200}
-                    />
-                  </View>
-                </TouchableOpacity>
               </View>
-            </View>
+            </TouchableOpacity>
           </View>
-
-          <TouchableOpacity
-            style={styles.bottomButtonWrapper}
-            disabled={!goalText}
-            onPress={() =>
-              router.push(
-                `/step4?category=${encodeURIComponent(
-                  (category as string) || '',
-                )}&goalText=${encodeURIComponent(goalText)}`,
-              )
-            }
-          >
-            <View
-              style={[
-                styles.button,
-                { backgroundColor: goalText ? Colors.main500 : Colors.gray100 },
-              ]}
-            >
-              <Text style={[Typo.heading02, { color: Colors.gray800 }]}>
-                다음
-              </Text>
-            </View>
-          </TouchableOpacity>
-        </SafeAreaView>
-      </TouchableWithoutFeedback>
-    </KeyboardAvoidingView>
+        </View>
+      </View>
+    </OnboardingLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.gray0,
-  },
-  titleWrapper: {
-    height: '10%',
-    paddingHorizontal: 20,
-    justifyContent: 'flex-end',
-    marginBottom: 15,
-  },
-  subtitleWrapper: {
-    marginTop: 8,
-    paddingHorizontal: 20,
-  },
   categoryContainer: {
     marginTop: 25,
     paddingHorizontal: 12,
@@ -165,21 +113,6 @@ const styles = StyleSheet.create({
   iconBox: {
     width: 20,
     height: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-
-  bottomButtonWrapper: {
-    position: 'absolute',
-    bottom: '5%',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  button: {
-    width: 336,
-    height: 60,
-    borderRadius: 12,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/app/(onboarding)/step3.tsx
+++ b/app/(onboarding)/step3.tsx
@@ -7,6 +7,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 
 import XIcon from '../../assets/icon/x.svg';
 import OnboardingLayout from '../../components/layout/OnboardingLayout';
+import StepButton from '../../components/shared/StepButton';
 import { Colors } from '../../constants/Colors';
 import { Typo } from '../../constants/Typo';
 
@@ -16,65 +17,69 @@ export default function ScreenCode() {
   const [goalText, setGoalText] = useState('');
 
   return (
-    <OnboardingLayout
-      title="STEP 2 목표 정의"
-      mainTitle={'해당 카테고리의\nMain Goal을 입력해주세요.'}
-      subtitle="이 카테고리를 통해 이루고 싶은 최종 목표를 자유롭게 적어보세요."
-      progress={0.4}
-      bottomButton={{
-        text: '다음',
-        onPress: () =>
+    <>
+      <OnboardingLayout
+        title="STEP 2 목표 정의"
+        mainTitle={'해당 카테고리의\nMain Goal을 입력해주세요.'}
+        subtitle="이 카테고리를 통해 이루고 싶은 최종 목표를 자유롭게 적어보세요."
+        progress={0.4}
+      >
+        <View style={styles.categoryContainer}>
+          <View style={styles.categoryBox}>
+            <Text style={[Typo.heading03, { color: Colors.gray900 }]}>
+              {category || '선택된 카테고리'}
+            </Text>
+          </View>
+        </View>
+        <View style={styles.inputContainer}>
+          <View
+            style={[
+              styles.inputBox,
+              {
+                borderBottomColor: goalText ? Colors.main600 : Colors.gray200,
+              },
+            ]}
+          >
+            <View style={styles.inputRow}>
+              <TextInput
+                style={[
+                  Typo.body02,
+                  {
+                    color: goalText ? Colors.gray600 : Colors.gray300,
+                    flex: 1,
+                  },
+                ]}
+                placeholder="이루고 싶은 목표 입력하기"
+                placeholderTextColor={Colors.gray300}
+                value={goalText}
+                onChangeText={setGoalText}
+              />
+              <TouchableOpacity onPress={() => setGoalText('')}>
+                <View style={styles.iconBox}>
+                  <XIcon
+                    width={20}
+                    height={20}
+                    color={goalText ? Colors.main600 : Colors.gray200}
+                  />
+                </View>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </OnboardingLayout>
+
+      <StepButton
+        text="다음"
+        onPress={() =>
           router.push(
             `/step4?category=${encodeURIComponent(
               (category as string) || '',
             )}&goalText=${encodeURIComponent(goalText)}`,
-          ),
-        disabled: !goalText,
-      }}
-    >
-      <View style={styles.categoryContainer}>
-        <View style={styles.categoryBox}>
-          <Text style={[Typo.heading03, { color: Colors.gray900 }]}>
-            {category || '선택된 카테고리'}
-          </Text>
-        </View>
-      </View>
-      <View style={styles.inputContainer}>
-        <View
-          style={[
-            styles.inputBox,
-            {
-              borderBottomColor: goalText ? Colors.main600 : Colors.gray200,
-            },
-          ]}
-        >
-          <View style={styles.inputRow}>
-            <TextInput
-              style={[
-                Typo.body02,
-                {
-                  color: goalText ? Colors.gray600 : Colors.gray300,
-                  flex: 1,
-                },
-              ]}
-              placeholder="이루고 싶은 목표 입력하기"
-              placeholderTextColor={Colors.gray300}
-              value={goalText}
-              onChangeText={setGoalText}
-            />
-            <TouchableOpacity onPress={() => setGoalText('')}>
-              <View style={styles.iconBox}>
-                <XIcon
-                  width={20}
-                  height={20}
-                  color={goalText ? Colors.main600 : Colors.gray200}
-                />
-              </View>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </View>
-    </OnboardingLayout>
+          )
+        }
+        disabled={!goalText}
+      />
+    </>
   );
 }
 

--- a/app/(onboarding)/step4.tsx
+++ b/app/(onboarding)/step4.tsx
@@ -16,6 +16,7 @@ import PenIcon from '../../assets/icon/pen.svg';
 import StarIcon from '../../assets/icon/star.svg';
 import XIcon from '../../assets/icon/x.svg';
 import OnboardingLayout from '../../components/layout/OnboardingLayout';
+import StepButton from '../../components/shared/StepButton';
 import { Colors } from '../../constants/Colors';
 import { Typo } from '../../constants/Typo';
 
@@ -64,26 +65,13 @@ export default function ScreenCode() {
   ];
 
   return (
-    <OnboardingLayout
-      title="STEP 3 목록화"
-      mainTitle={'이제 Main Goal을\n작은 단계들로 나누어 볼까요?'}
-      subtitle="작은 성공을 하나씩 쌓아가면 큰 목표도 더 쉽게 달성할 수 있어요!"
-      progress={0.6}
-      bottomButton={{
-        text: '다음',
-        onPress: () => {
-          const allSelectedGoals = [...selectedSubGoals, ...userAddedGoals];
-          router.push(
-            `/step5?mainGoal=${encodeURIComponent(
-              (mainGoal as string) || '',
-            )}&subGoals=${encodeURIComponent(
-              JSON.stringify(allSelectedGoals),
-            )}`,
-          );
-        },
-        disabled: !isNextButtonActive,
-      }}
-    >
+    <>
+      <OnboardingLayout
+        title="STEP 3 목록화"
+        mainTitle={'이제 Main Goal을\n작은 단계들로 나누어 볼까요?'}
+        subtitle="작은 성공을 하나씩 쌓아가면 큰 목표도 더 쉽게 달성할 수 있어요!"
+        progress={0.6}
+      >
       <ScrollView
         style={styles.scrollContainer}
         showsVerticalScrollIndicator={false}
@@ -227,7 +215,23 @@ export default function ScreenCode() {
               ))}
             </View>
           </ScrollView>
-    </OnboardingLayout>
+      </OnboardingLayout>
+
+      <StepButton
+        text="다음"
+        onPress={() => {
+          const allSelectedGoals = [...selectedSubGoals, ...userAddedGoals];
+          router.push(
+            `/step5?mainGoal=${encodeURIComponent(
+              (mainGoal as string) || '',
+            )}&subGoals=${encodeURIComponent(
+              JSON.stringify(allSelectedGoals),
+            )}`,
+          );
+        }}
+        disabled={!isNextButtonActive}
+      />
+    </>
   );
 }
 

--- a/app/(onboarding)/step4.tsx
+++ b/app/(onboarding)/step4.tsx
@@ -1,4 +1,3 @@
-// app/(onboarding)/start.tsx
 import { useState } from 'react';
 
 import {
@@ -9,24 +8,14 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import {
-  Keyboard,
-  KeyboardAvoidingView,
-  Platform,
-  TouchableOpacity,
-  TouchableWithoutFeedback,
-} from 'react-native';
+import { TouchableOpacity } from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import PenIcon from '../../assets/icon/pen.svg';
 import StarIcon from '../../assets/icon/star.svg';
 import XIcon from '../../assets/icon/x.svg';
-//컴포넌트
-import Header from '../../components/Header';
-import ProgressBar from '../../components/ProgressBar';
-//폰트, 컬러
+import OnboardingLayout from '../../components/layout/OnboardingLayout';
 import { Colors } from '../../constants/Colors';
 import { Typo } from '../../constants/Typo';
 
@@ -75,29 +64,30 @@ export default function ScreenCode() {
   ];
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    <OnboardingLayout
+      title="STEP 3 목록화"
+      mainTitle={'이제 Main Goal을\n작은 단계들로 나누어 볼까요?'}
+      subtitle="작은 성공을 하나씩 쌓아가면 큰 목표도 더 쉽게 달성할 수 있어요!"
+      progress={0.6}
+      bottomButton={{
+        text: '다음',
+        onPress: () => {
+          const allSelectedGoals = [...selectedSubGoals, ...userAddedGoals];
+          router.push(
+            `/step5?mainGoal=${encodeURIComponent(
+              (mainGoal as string) || '',
+            )}&subGoals=${encodeURIComponent(
+              JSON.stringify(allSelectedGoals),
+            )}`,
+          );
+        },
+        disabled: !isNextButtonActive,
+      }}
     >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <SafeAreaView style={styles.container}>
-          <Header title="STEP 3 목록화" />
-          <View style={styles.titleWrapper}>
-            <Text style={[Typo.title03, { color: Colors.gray900 }]}>
-              이제 Main Goal을{'\n'}작은 단계들로 나누어 볼까요?
-            </Text>
-          </View>
-          <ProgressBar progress={0.5} />
-          <View style={styles.subtitleWrapper}>
-            <Text style={[Typo.label02, { color: Colors.gray500 }]}>
-              작은 성공을 하나씩 쌓아가면 큰 목표도 더 쉽게 달성할 수 있어요!
-            </Text>
-          </View>
-
-          <ScrollView
-            style={styles.scrollContainer}
-            showsVerticalScrollIndicator={false}
-          >
+      <ScrollView
+        style={styles.scrollContainer}
+        showsVerticalScrollIndicator={false}
+      >
             <View style={styles.labelContainer}>
               <View style={styles.labelBox}>
                 <Text style={styles.labelText}>Main Goal</Text>
@@ -237,62 +227,11 @@ export default function ScreenCode() {
               ))}
             </View>
           </ScrollView>
-
-          <TouchableOpacity
-            style={styles.bottomButtonWrapper}
-            disabled={!isNextButtonActive}
-            onPress={() => {
-              const allSelectedGoals = [...selectedSubGoals, ...userAddedGoals];
-              router.push(
-                `/step5?mainGoal=${encodeURIComponent(
-                  (mainGoal as string) || '',
-                )}&subGoals=${encodeURIComponent(
-                  JSON.stringify(allSelectedGoals),
-                )}`,
-              );
-            }}
-          >
-            <View
-              style={[
-                styles.button,
-                {
-                  backgroundColor: isNextButtonActive
-                    ? Colors.main500
-                    : Colors.gray100,
-                },
-              ]}
-            >
-              <Text style={[Typo.heading02, { color: Colors.gray800 }]}>
-                다음
-              </Text>
-            </View>
-          </TouchableOpacity>
-        </SafeAreaView>
-      </TouchableWithoutFeedback>
-    </KeyboardAvoidingView>
+    </OnboardingLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.gray0,
-  },
-  backButtonWrapper: {
-    width: '100%',
-    height: 24,
-    padding: 20,
-  },
-  titleWrapper: {
-    height: '10%',
-    paddingHorizontal: 20,
-    justifyContent: 'flex-end',
-    marginBottom: 15,
-  },
-  subtitleWrapper: {
-    marginTop: 8,
-    paddingHorizontal: 20,
-  },
   labelContainer: {
     marginTop: 20,
     marginLeft: 16,
@@ -320,7 +259,7 @@ const styles = StyleSheet.create({
   },
   scrollContainer: {
     flex: 1,
-    marginBottom: 80,
+    paddingBottom: 10,
   },
   listContainer: {
     marginTop: 16,
@@ -368,45 +307,5 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 10,
-  },
-  categoryContainer: {
-    marginTop: 25,
-    paddingHorizontal: 12,
-  },
-  categoryBox: {
-    width: '100%',
-    paddingHorizontal: 24,
-    paddingVertical: 16,
-    backgroundColor: Colors.gray0,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: Colors.gray200,
-    justifyContent: 'flex-start',
-    alignItems: 'flex-start',
-  },
-  iconBox: {
-    width: 20,
-    height: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-
-  bottomButtonWrapper: {
-    position: 'absolute',
-    bottom: '5%',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  button: {
-    width: 336,
-    height: 60,
-    borderRadius: 12,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  inputWrapper: {
-    marginHorizontal: 20,
-    borderBottomWidth: 1,
   },
 });

--- a/app/(onboarding)/step5.tsx
+++ b/app/(onboarding)/step5.tsx
@@ -1,23 +1,10 @@
-// app/(onboarding)/start.tsx
-
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
-import {
-  Keyboard,
-  KeyboardAvoidingView,
-  Platform,
-  TouchableOpacity,
-  TouchableWithoutFeedback,
-} from 'react-native';
 
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import HappyTargetIcon from '../../assets/icon/dependent/happy_target.svg';
 import QuestionIcon from '../../assets/icon/dependent/question.svg';
-//컴포넌트
-import Header from '../../components/Header';
-import ProgressBar from '../../components/ProgressBar';
-//폰트, 컬러
+import OnboardingLayout from '../../components/layout/OnboardingLayout';
 import { Colors } from '../../constants/Colors';
 import { Typo } from '../../constants/Typo';
 
@@ -29,29 +16,21 @@ export default function ScreenCode() {
   const parsedSubGoals = subGoals ? JSON.parse(subGoals as string) : [];
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    <OnboardingLayout
+      title="STEP 4 학습 및 기억"
+      mainTitle={'계획을 일정에 등록하면\n더 꾸준히 이어갈 수 있어요.'}
+      subtitle="이제 이 세부계획을 언제, 어떻게 실천할지 정해볼까요?"
+      progress={0.8}
+      bottomButton={{
+        text: '캥거루틴 하러가기',
+        onPress: () => router.push('/step6'),
+        disabled: false,
+      }}
     >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <SafeAreaView style={styles.container}>
-          <Header title="STEP 4 학습 및 기억" />
-          <View style={styles.titleWrapper}>
-            <Text style={[Typo.title03, { color: Colors.gray900 }]}>
-              계획을 일정에 등록하면 {'\n'}더 꾸준히 이어갈 수 있어요.
-            </Text>
-          </View>
-          <ProgressBar progress={0.75} />
-          <View style={styles.subtitleWrapper}>
-            <Text style={[Typo.label02, { color: Colors.gray500 }]}>
-              이제 이 세부계획을 언제, 어떻게 실천할지 정해볼까요?
-            </Text>
-          </View>
-
-          <ScrollView
-            style={styles.scrollContainer}
-            showsVerticalScrollIndicator={false}
-          >
+      <ScrollView
+        style={styles.scrollContainer}
+        showsVerticalScrollIndicator={false}
+      >
             <View style={styles.labelContainer}>
               <View style={styles.labelBox}>
                 <QuestionIcon width={16} height={16} color={Colors.gray900} />
@@ -93,50 +72,11 @@ export default function ScreenCode() {
               ))}
             </View>
           </ScrollView>
-
-          <TouchableOpacity
-            style={styles.bottomButtonWrapper}
-            onPress={() => router.push('/step6')}
-          >
-            <View
-              style={[
-                styles.button,
-                {
-                  backgroundColor: Colors.main500,
-                },
-              ]}
-            >
-              <Text style={[Typo.heading02, { color: Colors.gray800 }]}>
-                캥거루틴 하러가기
-              </Text>
-            </View>
-          </TouchableOpacity>
-        </SafeAreaView>
-      </TouchableWithoutFeedback>
-    </KeyboardAvoidingView>
+    </OnboardingLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.gray0,
-  },
-  backButtonWrapper: {
-    width: '100%',
-    height: 24,
-    padding: 20,
-  },
-  titleWrapper: {
-    height: '10%',
-    paddingHorizontal: 20,
-    justifyContent: 'flex-end',
-    marginBottom: 15,
-  },
-  subtitleWrapper: {
-    marginTop: 8,
-    paddingHorizontal: 20,
-  },
   labelContainer: {
     marginTop: 20,
     marginLeft: 16,
@@ -160,26 +100,7 @@ const styles = StyleSheet.create({
   },
   scrollContainer: {
     flex: 1,
-    marginBottom: 80,
-  },
-
-  bottomButtonWrapper: {
-    position: 'absolute',
-    bottom: '5%',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  button: {
-    width: 336,
-    height: 60,
-    borderRadius: 12,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  inputWrapper: {
-    marginHorizontal: 20,
-    borderBottomWidth: 1,
+    paddingBottom: 10,
   },
   goalCard: {
     backgroundColor: Colors.gray0,

--- a/app/(onboarding)/step5.tsx
+++ b/app/(onboarding)/step5.tsx
@@ -5,6 +5,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import HappyTargetIcon from '../../assets/icon/dependent/happy_target.svg';
 import QuestionIcon from '../../assets/icon/dependent/question.svg';
 import OnboardingLayout from '../../components/layout/OnboardingLayout';
+import StepButton from '../../components/shared/StepButton';
 import { Colors } from '../../constants/Colors';
 import { Typo } from '../../constants/Typo';
 
@@ -16,63 +17,66 @@ export default function ScreenCode() {
   const parsedSubGoals = subGoals ? JSON.parse(subGoals as string) : [];
 
   return (
-    <OnboardingLayout
-      title="STEP 4 학습 및 기억"
-      mainTitle={'계획을 일정에 등록하면\n더 꾸준히 이어갈 수 있어요.'}
-      subtitle="이제 이 세부계획을 언제, 어떻게 실천할지 정해볼까요?"
-      progress={0.8}
-      bottomButton={{
-        text: '캥거루틴 하러가기',
-        onPress: () => router.push('/step6'),
-        disabled: false,
-      }}
-    >
-      <ScrollView
-        style={styles.scrollContainer}
-        showsVerticalScrollIndicator={false}
+    <>
+      <OnboardingLayout
+        title="STEP 4 학습 및 기억"
+        mainTitle={'계획을 일정에 등록하면\n더 꾸준히 이어갈 수 있어요.'}
+        subtitle="이제 이 세부계획을 언제, 어떻게 실천할지 정해볼까요?"
+        progress={0.8}
       >
-            <View style={styles.labelContainer}>
-              <View style={styles.labelBox}>
-                <QuestionIcon width={16} height={16} color={Colors.gray900} />
-                <Text style={styles.labelText}>Main Goal</Text>
+        <ScrollView
+          style={styles.scrollContainer}
+          showsVerticalScrollIndicator={false}
+        >
+              <View style={styles.labelContainer}>
+                <View style={styles.labelBox}>
+                  <QuestionIcon width={16} height={16} color={Colors.gray900} />
+                  <Text style={styles.labelText}>Main Goal</Text>
+                </View>
               </View>
-            </View>
 
-            <View style={styles.goalCard}>
-              <Text style={[Typo.body02, { color: Colors.gray600 }]}>
-                {(mainGoal as string) || '목표 없음'}
-              </Text>
-            </View>
-
-            <View style={styles.labelContainer}>
-              <View style={styles.labelBox}>
-                <HappyTargetIcon
-                  width={16}
-                  height={16}
-                  color={Colors.gray900}
-                />
-                <Text style={styles.labelText}>Sub Goal</Text>
-              </View>
-            </View>
-
-            <View style={styles.subGoalCard}>
-              {parsedSubGoals.map((goal: string, index: number) => (
-                <Text
-                  key={index}
-                  style={[
-                    Typo.body02,
-                    {
-                      color: Colors.gray600,
-                      marginBottom: index < parsedSubGoals.length - 1 ? 16 : 0,
-                    },
-                  ]}
-                >
-                  {goal}
+              <View style={styles.goalCard}>
+                <Text style={[Typo.body02, { color: Colors.gray600 }]}>
+                  {(mainGoal as string) || '목표 없음'}
                 </Text>
-              ))}
-            </View>
-          </ScrollView>
-    </OnboardingLayout>
+              </View>
+
+              <View style={styles.labelContainer}>
+                <View style={styles.labelBox}>
+                  <HappyTargetIcon
+                    width={16}
+                    height={16}
+                    color={Colors.gray900}
+                  />
+                  <Text style={styles.labelText}>Sub Goal</Text>
+                </View>
+              </View>
+
+              <View style={styles.subGoalCard}>
+                {parsedSubGoals.map((goal: string, index: number) => (
+                  <Text
+                    key={index}
+                    style={[
+                      Typo.body02,
+                      {
+                        color: Colors.gray600,
+                        marginBottom: index < parsedSubGoals.length - 1 ? 16 : 0,
+                      },
+                    ]}
+                  >
+                    {goal}
+                  </Text>
+                ))}
+              </View>
+            </ScrollView>
+      </OnboardingLayout>
+
+      <StepButton
+        text="캥거루틴 하러가기"
+        onPress={() => router.push('/step6')}
+        disabled={false}
+      />
+    </>
   );
 }
 

--- a/components/layout/OnboardingLayout.tsx
+++ b/components/layout/OnboardingLayout.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import {
+  Keyboard,
+  KeyboardAvoidingView,
+  Platform,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import Header from '../Header';
+import ProgressBar from '../ProgressBar';
+import { Colors } from '../../constants/Colors';
+import { Typo } from '../../constants/Typo';
+
+interface OnboardingLayoutProps {
+  title: string;
+  mainTitle: string;
+  subtitle: string;
+  progress: number;
+  children: React.ReactNode;
+  bottomButton: {
+    text: string;
+    onPress: () => void;
+    disabled?: boolean;
+  };
+}
+
+export default function OnboardingLayout({
+  title,
+  mainTitle,
+  subtitle,
+  progress,
+  children,
+  bottomButton,
+}: OnboardingLayoutProps) {
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <SafeAreaView style={styles.container}>
+          <Header title={title} />
+          <View style={styles.titleWrapper}>
+            <Text style={[Typo.title03, { color: Colors.gray900 }]}>
+              {mainTitle}
+            </Text>
+          </View>
+          <ProgressBar progress={progress} />
+          <View style={styles.subtitleWrapper}>
+            <Text style={[Typo.label02, { color: Colors.gray500 }]}>
+              {subtitle}
+            </Text>
+          </View>
+
+          <View style={styles.contentWrapper}>
+            {children}
+          </View>
+
+          <TouchableOpacity
+            style={styles.bottomButtonWrapper}
+            disabled={bottomButton.disabled}
+            onPress={bottomButton.onPress}
+          >
+            <View
+              style={[
+                styles.button,
+                {
+                  backgroundColor: bottomButton.disabled
+                    ? Colors.gray100
+                    : Colors.main500,
+                },
+              ]}
+            >
+              <Text style={[Typo.heading02, { color: Colors.gray800 }]}>
+                {bottomButton.text}
+              </Text>
+            </View>
+          </TouchableOpacity>
+        </SafeAreaView>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.gray0,
+  },
+  titleWrapper: {
+    height: '10%',
+    paddingHorizontal: 20,
+    justifyContent: 'flex-end',
+    marginBottom: 15,
+  },
+  subtitleWrapper: {
+    marginTop: 8,
+    paddingHorizontal: 20,
+  },
+  contentWrapper: {
+    flex: 1,
+    paddingTop: 10,
+    marginBottom: 70,
+  },
+  bottomButtonWrapper: {
+    position: 'absolute',
+    bottom: '5%',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  button: {
+    width: 336,
+    height: 60,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/components/layout/OnboardingLayout.tsx
+++ b/components/layout/OnboardingLayout.tsx
@@ -20,11 +20,6 @@ interface OnboardingLayoutProps {
   subtitle: string;
   progress: number;
   children: React.ReactNode;
-  bottomButton: {
-    text: string;
-    onPress: () => void;
-    disabled?: boolean;
-  };
 }
 
 export default function OnboardingLayout({
@@ -33,7 +28,6 @@ export default function OnboardingLayout({
   subtitle,
   progress,
   children,
-  bottomButton,
 }: OnboardingLayoutProps) {
   return (
     <KeyboardAvoidingView
@@ -58,27 +52,6 @@ export default function OnboardingLayout({
           <View style={styles.contentWrapper}>
             {children}
           </View>
-
-          <TouchableOpacity
-            style={styles.bottomButtonWrapper}
-            disabled={bottomButton.disabled}
-            onPress={bottomButton.onPress}
-          >
-            <View
-              style={[
-                styles.button,
-                {
-                  backgroundColor: bottomButton.disabled
-                    ? Colors.gray100
-                    : Colors.main500,
-                },
-              ]}
-            >
-              <Text style={[Typo.heading02, { color: Colors.gray800 }]}>
-                {bottomButton.text}
-              </Text>
-            </View>
-          </TouchableOpacity>
         </SafeAreaView>
       </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
@@ -103,20 +76,5 @@ const styles = StyleSheet.create({
   contentWrapper: {
     flex: 1,
     paddingTop: 10,
-    marginBottom: 70,
-  },
-  bottomButtonWrapper: {
-    position: 'absolute',
-    bottom: '5%',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  button: {
-    width: 336,
-    height: 60,
-    borderRadius: 12,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 });

--- a/components/shared/StepButton.tsx
+++ b/components/shared/StepButton.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { Colors } from '../../constants/Colors';
+import { Typo } from '../../constants/Typo';
+
+interface StepButtonProps {
+  text: string;
+  onPress: () => void;
+  disabled?: boolean;
+}
+
+export default function StepButton({ text, onPress, disabled = false }: StepButtonProps) {
+  return (
+    <TouchableOpacity
+      style={styles.bottomButtonWrapper}
+      disabled={disabled}
+      onPress={onPress}
+    >
+      <View
+        style={[
+          styles.button,
+          {
+            backgroundColor: disabled ? Colors.gray100 : Colors.main500,
+          },
+        ]}
+      >
+        <Text style={[Typo.heading02, { color: Colors.gray800 }]}>
+          {text}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  bottomButtonWrapper: {
+    position: 'absolute',
+    bottom: '5%',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  button: {
+    width: 336,
+    height: 60,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
## #️⃣ Issue Number

#33 

## 📝 요약(Summary)

- 온보딩 화면 헤더, 타이틀, 프로그래스바, 서브타이틀 -> components/layout/OnboardingLayout.tsx 로 이동 및 적용
- 하단 버튼 컴포넌트화 components/shared/StepButton.tsx


## 📸 스크린샷 

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
